### PR TITLE
Fix npm publish script

### DIFF
--- a/scripts/ci-npm-publish.sh
+++ b/scripts/ci-npm-publish.sh
@@ -30,7 +30,7 @@ pushd "${source_folder}"
 # collect package metadata. NOTE: the package_name is a scoped one.
 package_name=$(jq -crM '.name' <package.json)
 package_version=$(jq -crM '.version' <package.json)
-package_version_remote=$(npm info "$package_name"@"$package_version" version)
+package_version_remote=$(npm info "$package_name"@"$package_version" version || true)
 
 to_publish=0
 if [[ -z "$package_version_remote" ]]; then


### PR DESCRIPTION
Fix issue with npm publish script. `npm info` return non zero exit code (and stops following script execution) if we request info about package for which we publish first time and there are no any deployed versions in repository yet. 
When we published at least one version then it starts to return empty string when we request info about non existed version