### PR TITLE
Hotfix: ci-test.sh: Use npm ci and yarn --frozen-lockfile

### DIFF
--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -35,11 +35,11 @@ pushd "${source_folder}"
 
 if [[ -f "yarn.lock" ]]; then
   echo "Detected node.js project. Will run tests with yarn..."
-  (( SKIP_INSTALL == 0 )) && FORCE_COLOR=0 yarn --emoji false --non-interactive --no-progress
+  (( SKIP_INSTALL == 0 )) && FORCE_COLOR=0 yarn --emoji false --non-interactive --no-progress --frozen-lockfile
   FORCE_COLOR=0 yarn --emoji false --non-interactive --no-progress test
 elif [[ -f "package-lock.json" ]]; then
   echo "Detected node.js project. Will run tests with npm..."
-  (( SKIP_INSTALL == 0 )) && npm --no-color --legacy-peer-deps install
+  (( SKIP_INSTALL == 0 )) && npm --no-color --legacy-peer-deps ci
   npm --no-color test
 elif [[ -f "requirements.txt" ]]; then
   echo "Detected Python project. Will run pytest tests..."


### PR DESCRIPTION
**Change**
* `npm install` -> `npm ci`
* `yarn` -> `yarn --frozen-lockfile`

**Why?**
Otherwise `package-lock` might get modified.
