### PR TITLE
fix: ci-deploy.sh: Fix bash syntax issue for parameter expansion for INFRASTRUCTURE_FOLDERS

### DIFF
--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -36,7 +36,7 @@ fi
 # shellcheck source=.
 . "$dir"/ci-include.sh
 
-MODULES=("${INFRASTRUCTURE_FOLDERS//,/ }")
+MODULES=(${INFRASTRUCTURE_FOLDERS//,/ })
 
 # check that each module contains something deployable
 for module in "${MODULES[@]}"; do


### PR DESCRIPTION
By using double quoutes "" the resulting variable will not be an array - it will instead be a string with a space. By removing the double quotes "" bash will create an array which the loop can loop over